### PR TITLE
Fix Gradle 8 compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -37,7 +37,7 @@ buildscript {
 
 // Creating sources with comments
 task androidSourcesJar(type: Jar) {
-  classifier = 'sources'
+  archiveClassifier = 'sources'
   from android.sourceSets.main.java.srcDirs
 }
 


### PR DESCRIPTION
Could not set unknown property 'classifier' for task ':expo-play-asset-delivery:androidSourcesJar' #2.

Gradle 8 does no longer allow classifier inside Jar task. archiveClassifier must be used instead.

See https://docs.gradle.org/current/userguide/upgrading_version_7.html

    AbstractArchiveTask API Cleanup

    The deprecated appendix, archiveName, archivePath, baseName, classifier, desintationDir, extension and version properties of the AbstractArchiveTask task type have been removed. Use the archiveAppendix, archiveFileName , archiveFile, archiveBaseName, archiveClassifier, destinationDirectory, archiveExtension and archiveVersion properties instead.