### PR TITLE
Bump java version from 11 to 17 in compileOptions & kotlinOptions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -62,12 +62,12 @@ android {
   compileSdkVersion safeExtGet("compileSdkVersion", 31)
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
   }
 
   kotlinOptions {
-    jvmTarget = JavaVersion.VERSION_11.majorVersion
+    jvmTarget = JavaVersion.VERSION_17.majorVersion
   }
 
   defaultConfig {


### PR DESCRIPTION
I started using `expo-play-assets-delivery` with `expo@53.0.11`. However, when building `aab` package I was getting `Inconsistent JVM-target compatibility` error.

```[RUN_GRADLEW] FAILURE: Build failed with an exception.
[RUN_GRADLEW] * What went wrong:
[RUN_GRADLEW] Execution failed for task ':expo-play-asset-delivery:compileDebugKotlin'.
[RUN_GRADLEW] > Inconsistent JVM-target compatibility detected for tasks 'compileDebugJavaWithJavac' (17) and 'compileDebugKotlin' (11).
[RUN_GRADLEW]   
[RUN_GRADLEW]   Consider using JVM Toolchain: https://kotl.in/gradle/jvm/toolchain
[RUN_GRADLEW]   Learn more about JVM-target validation: https://kotl.in/gradle/jvm/target-validation 
[RUN_GRADLEW] * Try:
[RUN_GRADLEW] > Run with --stacktrace option to get the stack trace.
[RUN_GRADLEW] > Run with --info or --debug option to get more log output.
[RUN_GRADLEW] > Run with --scan to get full insights.
[RUN_GRADLEW] > Get more help at https://help.gradle.org.
[RUN_GRADLEW] BUILD FAILED in 11m 52s
```

This PR sets Java version to 17 and fixes the issue.