### PR TITLE
Bump asset-delivery dependency; Set compileSdkVersion & targetSdkVersion to 35

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,7 +59,7 @@ afterEvaluate {
 }
 
 android {
-  compileSdkVersion safeExtGet("compileSdkVersion", 31)
+  compileSdkVersion safeExtGet("compileSdkVersion", 35)
 
   compileOptions {
     sourceCompatibility JavaVersion.VERSION_17
@@ -72,7 +72,7 @@ android {
 
   defaultConfig {
     minSdkVersion safeExtGet("minSdkVersion", 21)
-    targetSdkVersion safeExtGet("targetSdkVersion", 31)
+    targetSdkVersion safeExtGet("targetSdkVersion", 35)
     versionCode 1
     versionName "0.1.0"
   }
@@ -89,6 +89,6 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
-  implementation 'com.google.android.play:asset-delivery:2.0.1'
-  implementation 'com.google.android.play:asset-delivery-ktx:2.0.1'
+  implementation 'com.google.android.play:asset-delivery:2.3.0'
+  implementation 'com.google.android.play:asset-delivery-ktx:2.3.0'
 }


### PR DESCRIPTION
This fixes the issue with uploading app to google play store via google play console. Old versions of dependencies were preventing this (see screenshot).

<img width="1133" height="96" alt="Screenshot 2025-08-09 at 23 31 35" src="https://github.com/user-attachments/assets/93d78022-a3b6-4e57-87a7-a5ba7d2f7c43" />

Works with expo 35.x.x. I haven't tried with older versions and I don't have a knowledge of how plugins' targetSdkVersion & compileSdkVersion interfere with older expo where these have lower values.
https://docs.expo.dev/versions/latest/#support-for-android-and-ios-versions